### PR TITLE
fixed incorrect option setting

### DIFF
--- a/socorro/unittest/cron/jobs/test_cleanup_radix.py
+++ b/socorro/unittest/cron/jobs/test_cleanup_radix.py
@@ -55,9 +55,8 @@ class TestCleanupRadix(TestCaseBase):
         config_manager, json_file = _super(
             'socorro.cron.jobs.cleanup_radix.RadixCleanupCronApp|1d',
             {
-                'crontabber.class-RadixCleanupCronApp.storage0': {
-                    'crashstorage_class': FSDatedRadixTreeStorage
-                }
+                'crontabber.class-RadixCleanupCronApp.dated_storage_classes':
+                    'socorro.external.fs.crashstorage.FSDatedRadixTreeStorage'
             }
         )
         return config_manager, json_file


### PR DESCRIPTION
it turns out that Tony did an unnecessary end run around configman when setting up his test.  The latest configman did not break the crazy `classes_in_namespaces_converter_with_compression` converter.  Tony just didn't give it the opportunity to work.
